### PR TITLE
Adding Unit Tests

### DIFF
--- a/Icarus Protocol/Assets/IcarusProtocolCore.asmdef
+++ b/Icarus Protocol/Assets/IcarusProtocolCore.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "IcarusProtocolCore",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Icarus Protocol/Assets/IcarusProtocolCore.asmdef.meta
+++ b/Icarus Protocol/Assets/IcarusProtocolCore.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4912d7aebba7e2844b7a9b9879d04ef8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Icarus Protocol/Assets/IronPythonIntegration/IronPythonContainer.cs
+++ b/Icarus Protocol/Assets/IronPythonIntegration/IronPythonContainer.cs
@@ -198,9 +198,6 @@ public class IronPythonContainer : MonoBehaviour
     {
         mSimulating = false;
         OnSimulationExit(this, (exitCode, optionalMessage));
-
-        //TODO: Remove Debug
-        Debug.Log(optionalMessage == "" ? $"Simulation exited with code: {exitCode}": $"Simulation exited with message {optionalMessage}");
     }
 
     /// <summary>

--- a/Icarus Protocol/Assets/Tests.meta
+++ b/Icarus Protocol/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da44fa44613d41742bed4c5164624b3e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Icarus Protocol/Assets/Tests/IronPythonTests.cs
+++ b/Icarus Protocol/Assets/Tests/IronPythonTests.cs
@@ -1,0 +1,235 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class IronPythonTests
+{
+    GameObject IPContainer;
+    IronPythonContainer IPRef;
+    PhaseDefinition PhaseRef;
+    (int, string) ExitData;
+    bool actionCalled;
+
+    /// <summary>
+    /// Sets up the framework for the IronPythonContainer and a test phase.
+    /// </summary>
+    [SetUp]
+    public void SetUp() 
+    {
+        ExitData = (-2, "");
+        actionCalled = false;
+
+        //Init test GameObject
+        IPContainer = new GameObject("IPContainer");
+        IPRef = IPContainer.AddComponent<IronPythonContainer>();
+
+        //Init test phase
+        PhaseRef = IPContainer.AddComponent<PhaseDefinition>();
+        PhaseRef.TestFile = new TextAsset(@"
+shouldPass = False
+privateShouldPass = False
+shouldFail = False
+
+def simulate():
+    global shouldPass
+    global privateShouldPass
+    global shouldFail
+
+    try:
+        parent.execute_user_code()
+    except Exception as e: 
+        parent.end_simulation(-1, repr(e))
+        return
+
+    environment.trigger_action_group(0)
+    parent.pull_user_scope()
+
+    if shouldFail:
+        parent.end_simulation(2)
+    elif shouldPass or privateShouldPass:
+        parent.end_simulation(0)
+    else:
+        parent.end_simulation(1)
+
+def simulate_tick():
+    return 0
+");
+        PhaseRef.ScriptFile = new TextAsset("Empty Script");
+        PhaseRef.ID = "test";
+        PhaseRef.FastTickSpeed = 0.1f;
+        PhaseRef.CodeLoopDuration = 0.1f;
+        PhaseRef.ActionGroups = new List<UnityEngine.Events.UnityEvent>();
+        PhaseRef.ResetGroup = new UnityEngine.Events.UnityEvent();
+        PhaseRef.ExposedMembers = new List<string>() {"shouldPass", "shouldFail"};
+        PhaseRef.FriendlyVariableNames = new List<string>();
+    }
+
+    /// <summary>
+    /// Tests that the IronPythonContainer can be initialized with a test phase, which gets properly cached.
+    /// </summary>
+    [Test]
+    public void IronPython_WhenInitialized_PhaseCached()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        Assert.AreEqual("test", IPRef.mCachedLevel.ID);
+    }
+
+    /// <summary>
+    /// Tests that utilities can fetch values from the Python simulation
+    /// </summary>
+    [Test]
+    public void IronPython_WhenGetPythonValue_CorrectValueFetched()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        Assert.AreEqual(false, (bool)IPRef.GetPythonValue("shouldPass"));
+    }
+
+    /// <summary>
+    /// Tests that malformed (exceptional) user code returns -1 and gives you an error message
+    /// </summary>
+    [UnityTest]
+    public IEnumerator IronPython_WhenBadUserCode_ReturnsException()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        IPRef.OnSimulationExit += IPRef_OnSimulationExit;
+        IPRef.Simulate("blah = blah blah");
+        LogAssert.Expect(LogType.Exception, "SyntaxErrorException: unexpected token 'blah'");
+
+        while (ExitData == (-2,"")) 
+        {
+            yield return null;
+        }
+
+        Assert.AreEqual(-1, ExitData.Item1);
+    }
+
+    /// <summary>
+    /// Tests that infinite loops are caught by the detector and return -1 with the correct response message
+    /// </summary>
+    [UnityTest]
+    public IEnumerator IronPython_WhenInfiniteLoop_ExitsCorrectly()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        IPRef.OnSimulationExit += IPRef_OnSimulationExit;
+        IPRef.Simulate(@"while True: pass");
+
+        while (ExitData == (-2, ""))
+        {
+            yield return null;
+        }
+
+        Assert.AreEqual(-1, ExitData.Item1);
+        Assert.AreEqual("This code locks up longer than it should. The most likely culprit is an infinite loop somewhere in the logic.", ExitData.Item2);
+    }
+
+    /// <summary>
+    /// Tests that the user isn't able to call forbidden functions like end_simulation from their isolated code
+    /// </summary>
+    [UnityTest]
+    public IEnumerator IronPython_WhenUserCallsForbiddenFunctions_ExitsWithError()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        IPRef.OnSimulationExit += IPRef_OnSimulationExit;
+        IPRef.Simulate(@"parent.end_simulation(0)");
+        LogAssert.Expect(LogType.Exception, "UnboundNameException: name 'parent' is not defined");
+
+        while (ExitData == (-2, ""))
+        {
+            yield return null;
+        }
+
+        Assert.AreEqual(-1, ExitData.Item1);
+    }
+
+    /// <summary>
+    /// Tests that successful code works and passes with exit code 0
+    /// </summary>
+    [UnityTest]
+    public IEnumerator IronPython_WhenUserIsCorrect_SimulationSucceeds()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        IPRef.OnSimulationExit += IPRef_OnSimulationExit;
+        IPRef.Simulate(@"shouldPass = True");
+
+        while (ExitData == (-2, ""))
+        {
+            yield return null;
+        }
+
+        Assert.AreEqual(0, ExitData.Item1);
+    }
+
+    /// <summary>
+    /// Tests that successful code works and passes with exit code 0
+    /// </summary>
+    [UnityTest]
+    public IEnumerator IronPython_WhenUserUsesPrivateVars_NothingHappens()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        IPRef.OnSimulationExit += IPRef_OnSimulationExit;
+        IPRef.Simulate(@"privateShouldPass = True");
+
+        while (ExitData == (-2, ""))
+        {
+            yield return null;
+        }
+
+        Assert.AreEqual(1, ExitData.Item1);
+    }
+
+    /// <summary>
+    /// Tests that expected logical failures return the correct error code
+    /// </summary>
+    [UnityTest]
+    public IEnumerator IronPython_WhenUserHasLogicError_ExpectedCodeReturned()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        IPRef.OnSimulationExit += IPRef_OnSimulationExit;
+        IPRef.Simulate(@"shouldFail = True");
+
+        while (ExitData == (-2, ""))
+        {
+            yield return null;
+        }
+
+        Assert.AreEqual(2, ExitData.Item1);
+    }
+
+    /// <summary>
+    /// Tests that action groups get called
+    /// </summary>
+    [UnityTest]
+    public IEnumerator IronPython_WhenCodeRun_ActionGroupCalled()
+    {
+        IPRef.InitializeLevel(PhaseRef);
+        IPRef.OnSimulationExit += IPRef_OnSimulationExit;
+        PhaseRef.ActionGroups.Add(new UnityEngine.Events.UnityEvent());
+        PhaseRef.ActionGroups[0].AddListener(TestAction);
+        IPRef.Simulate(@"");
+
+        while (ExitData == (-2, ""))
+        {
+            yield return null;
+        }
+
+        Assert.IsTrue(actionCalled);
+    }
+
+    /// <summary>
+    /// A callback function used to cache the return values of the IronPython simulation.
+    /// </summary>
+    private void IPRef_OnSimulationExit(object sender, (int, string) e)
+    {
+        ExitData = e;
+    }
+
+    /// <summary>
+    /// Used to pass tests if this action is called
+    /// </summary>
+    private void TestAction() 
+    {
+        actionCalled = true;
+    }
+}

--- a/Icarus Protocol/Assets/Tests/IronPythonTests.cs.meta
+++ b/Icarus Protocol/Assets/Tests/IronPythonTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0be3864e53c914e4ca1856423b25d151
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Icarus Protocol/Assets/Tests/Tests.asmdef
+++ b/Icarus Protocol/Assets/Tests/Tests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "IcarusProtocolCore"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Icarus Protocol/Assets/Tests/Tests.asmdef.meta
+++ b/Icarus Protocol/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5dbe0a27508fd0240a9f4bf94b846289
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
closes #57 

Demo Video Link:

Overview:

This PR covers the integration of the Unity Test Runner into the project, as well as the writing of a number of tests for the core IronPythonContainer class that handles the most integral and volatile logic.

Details:

Adding these behaviors required the addition of several files, one containing the actionable unit tests.

IronPythonTests.cs : Implements unit tests to automate verification of the behavior of the IronPythonContainer that runs user Python code and handles the core logic.

Testing:

All of the tests written in this PR were run in the unity unit test runner. As of the time of this PR, all tests are passing.